### PR TITLE
Add .theme file (Fish >=3.4)

### DIFF
--- a/themes/lighthaus.theme
+++ b/themes/lighthaus.theme
@@ -1,0 +1,71 @@
+# Lighthaus Color theme for Fish Shell
+# GIT: https://github.com/lighthaus-theme/fish
+# Author: Adhiraj Sirohi (https://github.com/brutuski)
+#         Vasundhara Sharma (https://github.com/vasundhasauras)
+
+# Copyright © 2021-Present Lighthaus Theme
+# Copyright © 2021-Present Adhiraj Sirohi
+# Copyright © 2021-Present Vasundhara Sharma
+
+# LIGHTHAUS COLORS
+# black:    18191E
+# brblack:  8E8D8D
+# red:      FC2929
+# brred:    FF5050
+# green:    44B273
+# brgreen:  50C16E
+# orange:   E25600
+# brorange: ED722E
+# blue:     1D918B
+# brblue:   47A8A1
+# purple:   D16BB7
+# brpurple: D68EB2
+# cyan:     00BFA4
+# brcyan:   5AD1AA
+# white:    CCCCCC
+# brwhite:  FFFADE
+# fg:       FFEE79
+# sel_fg:   FF4D00
+# sel_bg:   090B26
+# bold:     FFFF00
+
+fish_color_normal FFEE79
+fish_color_command 50C16E
+fish_color_quote 5AD1AA
+fish_color_redirection FFEE79
+fish_color_end ED722E
+fish_color_error FC2929
+fish_color_param ED722E
+fish_color_comment CCCCCC
+fish_color_match E25600
+fish_color_search_match FFFF00
+fish_color_operator 00BFA4
+fish_color_escape 47A8A1
+fish_color_cwd 5AD1AA
+fish_color_autosuggestion 8E8D8D
+fish_color_user 50C16E
+fish_color_host 47A8A1
+fish_color_cancel FF5050
+fish_color_cwd_root FC2929
+fish_color_history_current --bold
+fish_color_host_remote E25600
+fish_color_keyword 1D918B
+fish_color_option 00BFA4
+fish_color_selection CCCCCC --bold --background=8E8D8D
+fish_color_status FC2929
+fish_color_valid_path --underline
+
+fish_pager_color_prefix 47A8A1
+fish_pager_color_completion 5AD1AA
+fish_pager_color_description CCCCCC
+fish_pager_color_progress 8E8D8D
+fish_pager_color_secondary 8E8D8D
+fish_pager_color_background
+fish_pager_color_secondary_background
+fish_pager_color_secondary_completion
+fish_pager_color_secondary_description
+fish_pager_color_secondary_prefix
+fish_pager_color_selected_background -r
+fish_pager_color_selected_completion
+fish_pager_color_selected_description
+fish_pager_color_selected_prefix


### PR DESCRIPTION
In March 2022, Fish released [version 3.4](https://github.com/fish-shell/fish-shell/releases/tag/3.4.0), which defined a new way of handling themes. Setting themes no longer involves explicitly setting variables and instead uses `.theme` files in the `themes` directory (aka: `$__fish_conf_dir/themes`).

So, basically instead of using something like `~/.config/fish/conf.d/lighthaus.fish` to set a bunch of variables, you'd use `~/.config/fish/themes/lighthaus.theme`. Doing themes this way gives support for the builtin theme configuration commands: `fish_config theme (choose | demo | dump | list | save | show)`, as well as makes lighthaus appear in Fish's web config interface.

This PR adds the `lighthaus.theme` file, but does not remove support for older versions of Fish, nor does it force the use of a `.theme` file. If a user wants to use the new themes feature in a modern version of Fish (3.4-3.6 and beyond), they need only install lighthaus using Fisher or OMF as the instructions describe. (Fisher already supports theme plugins, not sure about OMF yet, but this PR is still safe because the default install is still the old way prior to themes.)

Once installed via their plugin manager, a user can then simply drop an empty `lighthaus.fish` in their `conf.d` to override the one that comes with this project if they want to use the `lighthaus.theme` file. The theme file can then be used by using the Fish built-in `fish_config` command. Lighthaus can then be selected either via the web interface, or by running `fish_config theme choose lighthaus`. This also allows Lighthaus to be installed alongside other great themes (eg: Tokyo Night, Dracula, etc.).